### PR TITLE
MAINT: Use color_labels; scale by 255

### DIFF
--- a/apps/correct-segmentation/app.py
+++ b/apps/correct-segmentation/app.py
@@ -152,8 +152,8 @@ def save_segmentation(labs, save_mode):
         new_labels = np.array(labs)
         np.save('labels.npy', new_labels)
         if save_mode == 'png':
-            color_labels = color.label2rgb(new_labels)
-            uri = array_to_data_url(new_labels, dtype=np.uint8)
+            color_labels = 255 * color.label2rgb(new_labels)
+            uri = array_to_data_url(color_labels, dtype=np.uint8)
             return uri
     else:
         raise PreventUpdate


### PR DESCRIPTION
The "download link" in app2 (manually correcting segmentation) produces an image that is very dark; see screenshot. I believe this is because the call to `array_to_data_url` uses `new_labels` but should be using `color_labels`. This PR changes that, and scales `color_labels` to be in the range 0 to 255 (needed for `PIL.Image.fromarray`). With these changes, a clearer (yet somewhat garish) image of the labels is produced.

Before
![before](https://user-images.githubusercontent.com/537559/62400294-a4f81180-b576-11e9-872d-adf48886a9d7.png)

After
![after](https://user-images.githubusercontent.com/537559/62400304-ab868900-b576-11e9-8510-7e126f9a25d3.png)
